### PR TITLE
Add unicode-normalization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,4 @@ tokio = { version = "1", features = ["full"] }
 diesel = { version = "2", features = ["postgres"] }
 dotenvy = "0.15"
 regex = "1"
+unicode-normalization = "0.1.20"

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use diesel::dsl::exists;
 use diesel::{prelude::*, select};
 use nostr_sdk::prelude::*;
 use regex::Regex;
+use unicode_normalization::UnicodeNormalization;
 
 use nostr_cpn_girl::*;
 use self::models::*;
@@ -67,7 +68,7 @@ async fn main() -> Result<()> {
                 match event.kind {
                     Kind::TextNote => {
                         let re = Regex::new(r"ログインボーナス|ログボ")?;
-                        if re.is_match(&event.content) {
+                        if re.is_match(&event.content.nfkc().collect::<String>()) {
                             let exists = select(
                                 exists(users.filter(id.eq(&event.pubkey.to_bech32()?))))
                                 .get_result::<bool>(connection)


### PR DESCRIPTION
Depending on the encoding method of Unicode, some dakuten (濁点) characters may be treated as separate codepoints, in which case it will not match correctly. Normalizing the content fixes this issue.

```rust
❯ evcxr
Welcome to evcxr. For help, type :help
>> :dep regex = "1"
>> use regex::Regex;
>> let re = Regex::new(r"ログインボーナス|ログボ")?;
>> let s = "\u{30ed}\u{30af}\u{3099}\u{30db}\u{3099}";
>> println!("{s}");
ログボ
>> re.is_match(s)
false
```

See MDN about Unicode normalization:
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/String/normalize