### PR TITLE
Change relay to connect to

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use self::models::*;
 
 const RELAY_URLS: [&str; 6] = [
     "wss://nostr.bitcoiner.social",
-    "wss://relay.snort.social",
+    "wss://nostr-relay.nokotaro.com/",
     "wss://relay.damus.io",
     "wss://relay.nostr.wirednet.jp",
     "wss://nos.lol",


### PR DESCRIPTION
Since `relay.snort.social` is now a paid relay, I would like logbo-chan to connect to `nostr-relay.nokotaro.com` instead, which has no IP restrictions.